### PR TITLE
fix: Corrects the nested level of the required field

### DIFF
--- a/schemas/PublicKeyEC.json
+++ b/schemas/PublicKeyEC.json
@@ -24,8 +24,8 @@
     "y": {
       "description": "EC curve point Y.",
       "$ref": "Base64URL.json"
-    },
-    "required": ["type", "curve", "x", "y"],
-    "additionalProperties": false
-  }
+    }
+  },
+  "required": ["type", "curve", "x", "y"],
+  "additionalProperties": false
 }

--- a/schemas/PublicKeyRSA.json
+++ b/schemas/PublicKeyRSA.json
@@ -16,8 +16,8 @@
     "e": {
       "description": "RSA exponent.",
       "$ref": "Base64URL.json"
-    },
-    "required": ["type", "n", "e"],
-    "additionalProperties": false
-  }
+    }
+  },
+  "required": ["type", "n", "e"],
+  "additionalProperties": false
 }


### PR DESCRIPTION
The required field was within the properties array. Therefore, the schema validator did not check

that the field specified by required does exist.