### PR TITLE
fix: update RpcReq/Res types

### DIFF
--- a/schemas/RpcRequest.json
+++ b/schemas/RpcRequest.json
@@ -19,7 +19,10 @@
     },
     "params": {
       "description": "Parameter values to be used during the invocation of the method",
-      "type": "object"
+      "oneOf": [
+        {"type": "object"},
+        {"type": "array"}
+      ]
     }
   },
   "required": ["jsonrpc", "method", "id"],

--- a/schemas/RpcResponse.json
+++ b/schemas/RpcResponse.json
@@ -11,8 +11,7 @@
           "description": "Distinguish responses from other messages",
           "oneOf": [
             {"type": "number"},
-            {"type": "string"},
-            {"type": "null"}
+            {"type": "string"}
           ]
         },
         "result": { "description": "the method's return value" }


### PR DESCRIPTION
* Allow `RpcRequest.params` to be an array (used by `broadcast_routes`)
* Don't allow `RpcResponse.id` to be `null`.