### PR TITLE
fix: switch to a sensible Identifier schema

### DIFF
--- a/schemas/Account.json
+++ b/schemas/Account.json
@@ -10,7 +10,7 @@
     },
     "name": {
       "description": "Name of the account",
-      "type": "string"
+      "$ref": "Identifier.json"
     },
     "balance": {
       "description": "Balance as decimal",

--- a/schemas/Identifier.json
+++ b/schemas/Identifier.json
@@ -3,5 +3,5 @@
   "title": "Identifier",
   "description": "An identifier for a user or institution.",
   "type": "string",
-  "pattern": "^([a-zA-Z0-9][a-zA-Z0-9-]{0,18}[a-zA-Z0-9]|([a-zA-Z0-9][a-zA-Z0-9-]{0,18}[a-zA-Z0-9]@)?((?!-)[a-zA-Z0-9-]{1,63}\\.)+(?!-)[a-zA-Z0-9-]{1,63})(?:\\:[0-9]{0,5})?$"
+  "pattern": "^[a-zA-Z0-9_-]{1,86}$"
 }


### PR DESCRIPTION
This regex is used by five-bells-ledger and ilp-kit to verify usernames, so it shouldn't allow weird email address looking things.

Also changed it so it doesn't allow multiple consecutive dashes in usernames.