### PR TITLE
Adds additional exception details if schema cannot be loaded

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,6 @@
 machine:
-  pre:
-    - curl https://raw.githubusercontent.com/creationix/nvm/v0.23.3/install.sh | bash
   node:
-    version: 6.9.1
+    version: 6.9
 test:
   override:
     - npm run lint

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -64,7 +64,7 @@ class Validator {
           let schemaJson = fs.readFileSync(path.join(dirPath, fileName), 'utf8')
           this.ajv.addSchema(JSON.parse(schemaJson), fileName)
         } catch (e) {
-          throw new ServerError('Failed to parse schema: ' + fileName)
+          throw new ServerError('Failed to parse schema: ' + fileName + '. Reason: ' + e)
         }
       })
   }


### PR DESCRIPTION
- Adds additional exception details if schema cannot be loaded
- Changes CI configuration so that `nvm` is not installed again (the build container has it already installed)