### PR TITLE
feat: make errors more declarative

### DIFF
--- a/errors/already-exists-error.js
+++ b/errors/already-exists-error.js
@@ -3,13 +3,10 @@
 const BaseError = require('./base-error')
 
 class AlreadyExistsError extends BaseError {
-  * handler (ctx, log) {
-    log.warn('Already Exists: ' + this.message)
-    ctx.status = 409
-    ctx.body = {
-      id: this.name,
-      message: this.message
-    }
+  constructor (message) {
+    super(message)
+
+    this.status = 409
   }
 }
 

--- a/errors/already-rolled-back-error.js
+++ b/errors/already-rolled-back-error.js
@@ -3,13 +3,10 @@
 const UnprocessableEntityError = require('./unprocessable-entity-error')
 
 class AlreadyRolledBackError extends UnprocessableEntityError {
-  * handler (ctx, log) {
-    log.warn('Already rolled back: ' + this.message)
-    ctx.status = 422
-    ctx.body = {
-      id: this.name,
-      message: this.message
-    }
+  constructor (message) {
+    super(message)
+
+    this.status = 422
   }
 }
 

--- a/errors/database-error.js
+++ b/errors/database-error.js
@@ -3,13 +3,10 @@
 const BaseError = require('./base-error')
 
 class DatabaseError extends BaseError {
-  * handler (ctx, log) {
-    log.warn('Database error: ' + this.message)
-    ctx.status = 500
-    ctx.body = {
-      id: this.name,
-      message: this.message
-    }
+  constructor (message) {
+    super(message)
+
+    this.status = 500
   }
 }
 

--- a/errors/invalid-body-error.js
+++ b/errors/invalid-body-error.js
@@ -5,10 +5,22 @@ const BaseError = require('./base-error')
 class InvalidBodyError extends BaseError {
   constructor (message, validationErrors) {
     super(message)
+
+    this.status = 400
     this.validationErrors = validationErrors
   }
 
   debugPrint (log, validationError, indent) {
+    if (!validationError) {
+      if (this.validationErrors) {
+        for (let ve of this.validationErrors) {
+          this.debugPrint(log, ve)
+        }
+      } else {
+        return
+      }
+    }
+
     indent = indent || ''
     log.debug(indent + '-- ' + validationError)
 
@@ -27,12 +39,10 @@ class InvalidBodyError extends BaseError {
     }
   }
 
-  * handler (ctx, log) {
+  async handler (ctx, log) {
     log.warn('Invalid body: ' + this.message)
     if (this.validationErrors) {
-      for (let ve of this.validationErrors) {
-        this.debugPrint(log, ve)
-      }
+      this.debugPrint(log)
     }
 
     ctx.status = 400

--- a/errors/invalid-modification-error.js
+++ b/errors/invalid-modification-error.js
@@ -5,6 +5,8 @@ const BaseError = require('./base-error')
 class InvalidModificationError extends BaseError {
   constructor (message, invalidDiffs) {
     super(message)
+
+    this.status = 400
     this.invalidDiffs = invalidDiffs
   }
 
@@ -30,12 +32,16 @@ class InvalidModificationError extends BaseError {
     }
   }
 
-  * handler (ctx, log) {
+  debugPrint (log) {
+    for (let diff of this.invalidDiffs) {
+      log.debug(' -- ' + this.formatDiff(diff))
+    }
+  }
+
+  async handler (ctx, log) {
     log.warn('Invalid Modification: ' + this.message)
     if (this.invalidDiffs) {
-      for (let diff of this.invalidDiffs) {
-        log.debug(' -- ' + this.formatDiff(diff))
-      }
+      this.debugPrint(log)
     }
     ctx.status = 400
     ctx.body = {

--- a/errors/invalid-uri-error.js
+++ b/errors/invalid-uri-error.js
@@ -5,10 +5,12 @@ const BaseError = require('./base-error')
 class InvalidUriError extends BaseError {
   constructor (message, validationErrors) {
     super(message)
+
+    this.status = 400
     this.validationErrors = validationErrors
   }
 
-  * handler (ctx, log) {
+  async handler (ctx, log) {
     log.warn('Invalid URI: ' + this.message)
     ctx.status = 400
     ctx.body = {

--- a/errors/invalid-uri-parameter-error.js
+++ b/errors/invalid-uri-parameter-error.js
@@ -5,10 +5,12 @@ const InvalidUriError = require('./invalid-uri-error')
 class InvalidUriParameterError extends InvalidUriError {
   constructor (message, validationErrors) {
     super(message)
+
+    this.status = 400
     this.validationErrors = validationErrors
   }
 
-  * handler (ctx, log) {
+  async handler (ctx, log) {
     log.warn('Invalid URI parameter: ' + this.message)
     ctx.status = 400
     ctx.body = {

--- a/errors/not-found-error.js
+++ b/errors/not-found-error.js
@@ -3,13 +3,10 @@
 const BaseError = require('./base-error')
 
 class NotFoundError extends BaseError {
-  * handler (ctx, log) {
-    log.warn('Not Found: ' + this.message)
-    ctx.status = 404
-    ctx.body = {
-      id: this.name,
-      message: this.message
-    }
+  constructor (message) {
+    super(message)
+
+    this.status = 404
   }
 }
 

--- a/errors/server-error.js
+++ b/errors/server-error.js
@@ -3,13 +3,10 @@
 const BaseError = require('./base-error')
 
 class ServerError extends BaseError {
-  * handler (ctx, log) {
-    log.warn('Server error: ' + this.message)
-    ctx.status = 500
-    ctx.body = {
-      id: this.name,
-      message: this.message
-    }
+  constructor (message) {
+    super(message)
+
+    this.status = 500
   }
 }
 

--- a/errors/transfer-not-conditional-error.js
+++ b/errors/transfer-not-conditional-error.js
@@ -3,13 +3,10 @@
 const UnprocessableEntityError = require('./unprocessable-entity-error')
 
 class TransferNotConditionalError extends UnprocessableEntityError {
-  * handler (ctx, log) {
-    log.warn('Transfer Not Conditional: ' + this.message)
-    ctx.status = 422
-    ctx.body = {
-      id: this.name,
-      message: this.message
-    }
+  constructor (message) {
+    super(message)
+
+    this.status = 422
   }
 }
 

--- a/errors/unauthorized-error.js
+++ b/errors/unauthorized-error.js
@@ -5,16 +5,9 @@ const BaseError = require('./base-error')
 class UnauthorizedError extends BaseError {
   constructor (message, validationErrors) {
     super(message)
-    this.validationErrors = validationErrors
-  }
 
-  * handler (ctx, log) {
-    log.warn('Unauthorized: ' + this.message)
-    ctx.status = 403
-    ctx.body = {
-      id: this.name,
-      message: this.message
-    }
+    this.status = 403
+    this.validationErrors = validationErrors
   }
 }
 

--- a/errors/unmet-condition-error.js
+++ b/errors/unmet-condition-error.js
@@ -3,13 +3,10 @@
 const UnprocessableEntityError = require('./unprocessable-entity-error')
 
 class UnmetConditionError extends UnprocessableEntityError {
-  * handler (ctx, log) {
-    log.warn('Execution Condition Not Met: ' + this.message)
-    ctx.status = 422
-    ctx.body = {
-      id: this.name,
-      message: this.message
-    }
+  constructor (message) {
+    super(message)
+
+    this.status = 422
   }
 }
 

--- a/errors/unprocessable-entity-error.js
+++ b/errors/unprocessable-entity-error.js
@@ -3,13 +3,10 @@
 const BaseError = require('./base-error')
 
 class UnprocessableEntityError extends BaseError {
-  * handler (ctx, log) {
-    log.warn('Unprocessable: ' + this.message)
-    ctx.status = 422
-    ctx.body = {
-      id: this.name,
-      message: this.message
-    }
+  constructor (message) {
+    super(message)
+
+    this.status = 422
   }
 }
 

--- a/middlewares/error-handler.js
+++ b/middlewares/error-handler.js
@@ -10,12 +10,13 @@ module.exports = function (opts) {
       if (typeof err.handler === 'function') {
         yield err.handler(this, log)
       } else {
-        log.error(err)
-        if (typeof err === 'object' && err.stack) {
-          log.error(err.stack)
-        }
+        log.warn(err.stack || (err.name + ': ' + err.message))
 
-        this.throw(err.status || 500, err.name + ': ' + err.message)
+        this.status = err.statusCode || err.status || 500
+        this.body = {
+          id: err.name,
+          message: err.message
+        }
 
         // We consider the error handled at this point, so we do NOT reemit it,
         // that's why the following line is commented out.


### PR DESCRIPTION
By adding a status property we can get rid of most of the custom errors handlers.

This PR is a stepping stone in a long-standing quest to get rid of five-bells-shared in favor of more widely used modules created by the Node community.