### PR TITLE
feat: allow any rejection message

### DIFF
--- a/schemas/FundsTemplate.json
+++ b/schemas/FundsTemplate.json
@@ -33,7 +33,7 @@
     },
     "rejection_message": {
       "description": "The reason the credit was rejected",
-      "$ref": "RejectionMessage.json"
+      "type": "object"
     }
   },
   "required": ["account", "amount"],


### PR DESCRIPTION
Ledgers should not try to validate ILP-layer data.

Five Bells Ledger, for example, allows arbitrary memos to be placed on funds (`memo`) and transfers (`additional_info`). The one exception is the `rejection_message` which the ledger attempts to validate according to some schema. It shouldn't.